### PR TITLE
time-1.5 compatibility

### DIFF
--- a/src/System/Log/Formatter.hs
+++ b/src/System/Log/Formatter.hs
@@ -28,8 +28,12 @@ import Control.Concurrent (myThreadId)
 import System.Posix.Process (getProcessID)
 #endif
 
-import System.Locale (defaultTimeLocale)
 import Data.Time (getZonedTime,getCurrentTime,formatTime)
+#if MIN_VERSION_time(1,5,0)
+import Data.Time (defaultTimeLocale)
+#else
+import System.Locale (defaultTimeLocale)
+#endif
 
 import System.Log
 

--- a/src/System/Log/Handler/Log4jXML.hs
+++ b/src/System/Log/Handler/Log4jXML.hs
@@ -109,8 +109,10 @@ import Control.Concurrent (ThreadId, myThreadId)  -- myThreadId is GHC only!
 import Control.Concurrent.MVar
 import Data.List (isPrefixOf)
 import System.IO
-import System.Locale (defaultTimeLocale)
 import Data.Time
+#if !MIN_VERSION_time(1,5,0)
+import System.Locale (defaultTimeLocale)
+#endif
 import System.Log
 import System.Log.Handler
 import System.Log.Handler.Simple (streamHandler, GenericHandler(..))


### PR DESCRIPTION
The `time` package now exposes its own `TimeLocale`.