### PR TITLE
exception handling fix

### DIFF
--- a/hslogger.cabal
+++ b/hslogger.cabal
@@ -1,5 +1,5 @@
 Name: hslogger
-Version: 1.2.10
+Version: 1.2.11
 License: BSD3
 Maintainer: John Goerzen <jgoerzen@complete.org>
 Author: John Goerzen


### PR DESCRIPTION
Fix improper use of "catch" function. It does not suppose to catch
all exception in this case. For example, the "ThreadKilled" exception
during "catch" call did not stop the thread.

Using "tryJust" to catch only particular exception instead.
