### PR TITLE
Use foldr instead of deprecated fold.

### DIFF
--- a/src/System/Log/Logger.hs
+++ b/src/System/Log/Logger.hs
@@ -476,7 +476,7 @@ updateGlobalLogger ln func =
 removeAllHandlers :: IO ()
 removeAllHandlers =
     modifyMVar_ logTree $ \lt -> do
-        let allHandlers = Map.fold (\l r -> concat [r, handlers l]) [] lt
+        let allHandlers = Map.foldr (\l r -> concat [r, handlers l]) [] lt
         mapM_ (\(HandlerT h) -> close h) allHandlers
         return $ Map.map (\l -> l {handlers = []}) lt
 


### PR DESCRIPTION
They are equivalent, and were so in the prior release.

Closes #46 